### PR TITLE
Store language in sharedPreferences

### DIFF
--- a/app/src/main/java/io/techup/android/languagepreference/MainActivity.java
+++ b/app/src/main/java/io/techup/android/languagepreference/MainActivity.java
@@ -1,6 +1,8 @@
 package io.techup.android.languagepreference;
 
+import android.content.Context;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -11,9 +13,12 @@ import android.view.MenuItem;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.io.IOException;
+
 public class MainActivity extends AppCompatActivity {
 
     TextView languageTv;
+    SharedPreferences sharedPreferences;
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -22,16 +27,21 @@ public class MainActivity extends AppCompatActivity {
         switch (item.getItemId()) {
             case R.id.menu_english:
                 languageTv.setText("English");
+                saveSelectedLanguage("English");
                 return true;
 
 
             case R.id.menu_spanish:
                 languageTv.setText("Spanish");
+                saveSelectedLanguage("Spanish");
+                return true;
+            case R.id.menu_reset:
+                languageTv.setText("");
+                saveSelectedLanguage("");
                 return true;
             default:
                 return false;
         }
-
 
 
     }
@@ -48,24 +58,39 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
+        sharedPreferences = this.getSharedPreferences("io.techup.android.languagepreference", Context.MODE_PRIVATE);
         languageTv = (TextView) findViewById(R.id.tv_language);
-        new AlertDialog.Builder(this)
-                .setIcon(R.drawable.ic_language_black_24dp)
-                .setTitle("Choose a language")
-                .setMessage("Which language do you like?")
-                .setPositiveButton("SPANISH", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        languageTv.setText("Spanish");
-                    }
-                })
-                .setNegativeButton("ENGLISH", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        languageTv.setText("English");
-                    }
-                })
-                .show();
+
+        languageTv.setText(sharedPreferences.getString("language", ""));
+        if(languageTv.getText() == ""){
+            new AlertDialog.Builder(this)
+                    .setIcon(R.drawable.ic_language_black_24dp)
+                    .setTitle("Choose a language")
+                    .setMessage("Which language do you like?")
+                    .setPositiveButton("SPANISH", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            languageTv.setText("Spanish");
+                            saveSelectedLanguage("Spanish");
+
+                        }
+                    })
+                    .setNegativeButton("ENGLISH", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialogInterface, int i) {
+                            languageTv.setText("English");
+                            saveSelectedLanguage("English");
+                        }
+                    })
+                    .show();
+        }
+
     }
+
+    private void saveSelectedLanguage(String language) {
+        sharedPreferences.edit().putString("language", language).apply();
+
+    }
+
+
 }

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -5,4 +5,6 @@
         android:id="@+id/menu_spanish" />
     <item android:title="English"
         android:id="@+id/menu_english" />
+    <item android:title="Reset Settings"
+        android:id="@+id/menu_reset" />
 </menu>


### PR DESCRIPTION
## Description

This allows the language selected to be stored in sharedPreference and be restored when reloading the application. Menu item reset is added to display the alert dialog again.